### PR TITLE
Use new APIs added in v4.1.0 to simplify remote chunking configuration

### DIFF
--- a/remote-chunking/pom.xml
+++ b/remote-chunking/pom.xml
@@ -49,6 +49,7 @@
 		<dependency>
 			<groupId>org.springframework.batch</groupId>
 			<artifactId>spring-batch-integration</artifactId>
+			<version>4.1.0.M2</version>
 		</dependency>
 
 		<dependency>

--- a/remote-chunking/src/main/java/io/spring/batch/remotechunking/RemoteChunkingApplication.java
+++ b/remote-chunking/src/main/java/io/spring/batch/remotechunking/RemoteChunkingApplication.java
@@ -5,10 +5,12 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.integration.config.annotation.EnableBatchIntegration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @EnableBatchProcessing
+@EnableBatchIntegration
 @SpringBootApplication
 public class RemoteChunkingApplication {
 


### PR DESCRIPTION
Hi Michael,

This PR shows how to use the new builders to simplify remote chunking setup.
It uses the 4.1.0.BUILD-SNAPSHOT version that you need to build and install locally after applying the changes of [this PR](https://github.com/spring-projects/spring-batch/pull/599).

This PR is not meant to be merged. I just submit it as a showcase and as a support for our discussion.

Kr,
Mahmoud