### PR TITLE
Add sample using new APIs added in v4.1.0 to simplify remote partitioning

### DIFF
--- a/partitioned-demo/src/main/java/io/spring/batch/partitiondemo/configuration/MasterConfiguration.java
+++ b/partitioned-demo/src/main/java/io/spring/batch/partitiondemo/configuration/MasterConfiguration.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.spring.batch.partitiondemo.configuration;
+
+import org.springframework.amqp.core.AmqpTemplate;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.partition.support.MultiResourcePartitioner;
+import org.springframework.batch.integration.config.annotation.EnableBatchIntegration;
+import org.springframework.batch.integration.partition.RemotePartitioningMasterStepBuilderFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.io.Resource;
+import org.springframework.integration.amqp.dsl.Amqp;
+import org.springframework.integration.channel.DirectChannel;
+import org.springframework.integration.dsl.IntegrationFlow;
+import org.springframework.integration.dsl.IntegrationFlows;
+
+@Configuration
+@EnableBatchProcessing
+@EnableBatchIntegration
+@Profile("master")
+public class MasterConfiguration {
+
+	private final JobBuilderFactory jobBuilderFactory;
+
+	private final RemotePartitioningMasterStepBuilderFactory masterStepBuilderFactory;
+
+
+	public MasterConfiguration(JobBuilderFactory jobBuilderFactory,
+							   RemotePartitioningMasterStepBuilderFactory masterStepBuilderFactory) {
+
+		this.jobBuilderFactory = jobBuilderFactory;
+		this.masterStepBuilderFactory = masterStepBuilderFactory;
+	}
+
+	/*
+	 * Configure outbound flow (requests going to workers)
+	 */
+	@Bean
+	public DirectChannel requests() {
+		return new DirectChannel();
+	}
+
+	@Bean
+	public IntegrationFlow outboundFlow(AmqpTemplate amqpTemplate) {
+		return IntegrationFlows.from(requests())
+				.handle(Amqp.outboundAdapter(amqpTemplate)
+						.routingKey("requests"))
+				.get();
+	}
+
+	/*
+	 * Configure the master step
+	 */
+
+	@Bean
+	@StepScope
+	public MultiResourcePartitioner partitioner(@Value("#{jobParameters['inputFiles']}") Resource[] resources) {
+		MultiResourcePartitioner partitioner = new MultiResourcePartitioner();
+
+		partitioner.setKeyName("file");
+		partitioner.setResources(resources);
+
+		return partitioner;
+	}
+
+	@Bean
+	public Step masterStep() {
+		return this.masterStepBuilderFactory.get("masterStep")
+				.partitioner("workerStep", partitioner(null))
+				.outputChannel(requests())
+				.build();
+	}
+
+	@Bean
+	public Job remotePartitioningJob() {
+		return this.jobBuilderFactory.get("remotePartitioningJob")
+				.start(masterStep())
+				.build();
+	}
+
+}

--- a/partitioned-demo/src/main/java/io/spring/batch/partitiondemo/configuration/WorkerConfiguration.java
+++ b/partitioned-demo/src/main/java/io/spring/batch/partitiondemo/configuration/WorkerConfiguration.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.spring.batch.partitiondemo.configuration;
+
+import javax.sql.DataSource;
+
+import io.spring.batch.partitiondemo.domain.Transaction;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.integration.config.annotation.EnableBatchIntegration;
+import org.springframework.batch.integration.partition.RemotePartitioningWorkerStepBuilderFactory;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.database.JdbcBatchItemWriter;
+import org.springframework.batch.item.database.builder.JdbcBatchItemWriterBuilder;
+import org.springframework.batch.item.file.FlatFileItemReader;
+import org.springframework.batch.item.file.builder.FlatFileItemReaderBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.io.Resource;
+import org.springframework.integration.amqp.dsl.Amqp;
+import org.springframework.integration.channel.DirectChannel;
+import org.springframework.integration.dsl.IntegrationFlow;
+import org.springframework.integration.dsl.IntegrationFlows;
+
+@Configuration
+@EnableBatchProcessing
+@EnableBatchIntegration
+@Profile("!master")
+public class WorkerConfiguration {
+
+	private final RemotePartitioningWorkerStepBuilderFactory workerStepBuilderFactory;
+
+
+	public WorkerConfiguration(RemotePartitioningWorkerStepBuilderFactory workerStepBuilderFactory) {
+		this.workerStepBuilderFactory = workerStepBuilderFactory;
+	}
+
+	/*
+	 * Configure inbound flow (requests coming from the master)
+	 */
+	@Bean
+	public Queue requestQueue() {
+		return new Queue("requests", false);
+	}
+
+	@Bean
+	public TopicExchange exchange() {
+		return new TopicExchange("remote-partitioning-exchange");
+	}
+
+	@Bean
+	public Binding requestBinding(TopicExchange exchange) {
+		return BindingBuilder.bind(requestQueue()).to(exchange).with("requests");
+	}
+
+	@Bean
+	public DirectChannel requests() {
+		return new DirectChannel();
+	}
+
+	@Bean
+	public IntegrationFlow inboundFlow(ConnectionFactory connectionFactory) {
+		return IntegrationFlows
+				.from(Amqp.inboundAdapter(connectionFactory, "requests"))
+				.channel(requests())
+				.get();
+	}
+
+	/*
+	 * Configure the worker step
+	 */
+	@Bean
+	public Step workerStep() {
+		return this.workerStepBuilderFactory.get("workerStep")
+				.inputChannel(requests())
+				.<Transaction, Transaction>chunk(100)
+				.reader(fileTransactionReader(null))
+				.processor((ItemProcessor<Transaction, Transaction>) transaction -> {
+					System.out.println("processing transaction = " + transaction);
+					return transaction;
+				})
+				.writer(writer(null))
+				.build();
+	}
+
+	@Bean
+	@StepScope
+	public FlatFileItemReader<Transaction> fileTransactionReader(
+			@Value("#{stepExecutionContext['file']}") Resource resource) {
+
+		return new FlatFileItemReaderBuilder<Transaction>()
+				.name("flatFileTransactionReader")
+				.resource(resource)
+				.delimited()
+				.names(new String[] {"account", "amount", "timestamp"})
+				.fieldSetMapper(fieldSet -> {
+					Transaction transaction = new Transaction();
+
+					transaction.setAccount(fieldSet.readString("account"));
+					transaction.setAmount(fieldSet.readBigDecimal("amount"));
+					transaction.setTimestamp(fieldSet.readDate("timestamp", "yyyy-MM-dd HH:mm:ss"));
+
+					return transaction;
+				})
+				.build();
+	}
+
+	@Bean
+	@StepScope
+	public JdbcBatchItemWriter<Transaction> writer(DataSource dataSource) {
+		return new JdbcBatchItemWriterBuilder<Transaction>()
+				.dataSource(dataSource)
+				.beanMapped()
+				.sql("INSERT INTO TRANSACTION (ACCOUNT, AMOUNT, TIMESTAMP) VALUES (:account, :amount, :timestamp)")
+				.build();
+	}
+
+}


### PR DESCRIPTION
This PR implements the same use case shown in the `remote-chunking` module but with a remote partitioning setup.

I've got some dependency issues when compiling the sample because the `partitioned-demo` uses boot `1.5.6.RELEASE` while `remote-chunking` uses boot `2.0.0.RC1`. The sample in this PR works as expected with boot `2.0.0.RC1` (and same dependencies as the `remote-chunking` module).